### PR TITLE
Themes: Make parse() method in FontListParser public

### DIFF
--- a/graphics/java/android/graphics/Typeface.java
+++ b/graphics/java/android/graphics/Typeface.java
@@ -369,7 +369,8 @@ public class Typeface {
         }
 
         try {
-            FontListParser.Config fontConfig = FontListParser.parse(configFile, fontDir);
+            FontListParser.Config fontConfig = FontListParser.parse(configFile,
+                    fontDir.getAbsolutePath());
             FontListParser.Config systemFontConfig = null;
 
             // If the fonts are coming from a theme, we will need to make sure that we include
@@ -377,7 +378,7 @@ public class Typeface {
             // NOTE: All the system font families without names ALWAYS get added.
             if (configFile == themeConfigFile) {
                 systemFontConfig = FontListParser.parse(systemConfigFile,
-                        getSystemFontDirLocation());
+                        getSystemFontDirLocation().getAbsolutePath());
                 addMissingFontFamilies(systemFontConfig, fontConfig);
                 addMissingFontAliases(systemFontConfig, fontConfig);
                 addFallbackFontsForFamilyName(systemFontConfig, fontConfig, SANS_SERIF_FAMILY_NAME);
@@ -428,11 +429,11 @@ public class Typeface {
             Log.w(TAG, "Didn't create default family (most likely, non-Minikin build)", e);
             // TODO: normal in non-Minikin case, remove or make error when Minikin-only
         } catch (FileNotFoundException e) {
-            Log.e(TAG, "Error opening " + configFile);
+            Log.e(TAG, "Error opening " + configFile, e);
         } catch (IOException e) {
-            Log.e(TAG, "Error reading " + configFile);
+            Log.e(TAG, "Error reading " + configFile, e);
         } catch (XmlPullParserException e) {
-            Log.e(TAG, "XML parse exception for " + configFile);
+            Log.e(TAG, "XML parse exception for " + configFile, e);
         }
     }
 


### PR DESCRIPTION
This allows other apps, such as the Theme Chooser, to use the parser
without needing to duplicate code.  Methods were generalized to use
input streams that support marking so that the stream can be reset
after checking if the xml is in the legacy format.

Change-Id: Id77adabba836267e3dfcdd536b2859d3faa7d78d
REF: CHOOSER-83
